### PR TITLE
Dockerize (fixes #7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 lib/__pycache__/
+resources/
 chromedriver.exe
 data.txt
 login.py

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ __pycache__/
 lib/__pycache__/
 resources/
 chromedriver.exe
-data.txt
 login.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.8.6-slim-buster
+
+ENV CHROMEDRIVER_VERSION 86.0.4240.22
+
+WORKDIR /usr/src/app
+
+RUN apt-get update && \
+    apt-get install -y curl unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -O https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip && \
+    unzip chromedriver_linux64.zip
+
+COPY requirements.txt ./
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT [ "python3" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN groupadd -r app && adduser --system --home /home/app --ingroup app app && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -O https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip && \
-    unzip chromedriver_linux64.zip
+    unzip chromedriver_linux64.zip && \
+    rm -f chromedriver_linux64.zip
 
 COPY requirements.txt ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
 FROM python:3.8.6-slim-buster
 
-ENV CHROMEDRIVER_VERSION 86.0.4240.22
+ENV CHROMEDRIVER_VERSION 85.0.4183.87
+ENV CHROME_VERSION 85.0.4183.121-1
 
 WORKDIR /usr/src/app
 
-RUN apt-get update && \
-    apt-get install -y curl unzip && \
+RUN groupadd -r app && adduser --system --home /home/app --ingroup app app && \
+    chown -R app:app /usr/src/app && \
+    apt-get update && \
+    apt-get install -y curl unzip gnupg && \
+    curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
+    apt-get update && \
+    apt-get install -y google-chrome-stable=${CHROME_VERSION} && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -O https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip && \
@@ -16,5 +23,7 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+
+USER app
 
 ENTRYPOINT [ "python3" ]

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ docker build -t ghunt .
 Any of the scripts can be invoked through:
 
 ```
-docker run --privileged -v $(pwd)/resources:/usr/src/app/resources -ti ghunt check_and_gen.py
-docker run --privileged -v $(pwd)/resources:/usr/src/app/resources -ti ghunt hunt.py <email_address>
+docker run -v $(pwd)/resources:/usr/src/app/resources -ti ghunt check_and_gen.py
+docker run -v $(pwd)/resources:/usr/src/app/resources -ti ghunt hunt.py <email_address>
 ```
 
 ## Manual installation

--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ Either this is a bug and this will be fixed, either it's a protection that we ne
 - **02/10/2020** : I found a bypass, I'm working on the patch right now.
 
 # Installation
+
+## Docker
+
+You can build the Docker image with:
+
+```
+docker build -t ghunt .
+```
+
+Any of the scripts can be invoked through:
+
+```
+docker run -v $(pwd)/resources:/usr/src/app/resources -ti ghunt check_and_gen.py
+docker run -v $(pwd)/resources:/usr/src/app/resources -ti ghunt hunt.py <email_address>
+```
+
+## Manual installation
 - Python 3.6+ would be ok. (I developed it with Python 3.8.1)
 - These Python modules are required (we'll install them after):
 ```

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ docker build -t ghunt .
 Any of the scripts can be invoked through:
 
 ```
-docker run -v $(pwd)/resources:/usr/src/app/resources -ti ghunt check_and_gen.py
-docker run -v $(pwd)/resources:/usr/src/app/resources -ti ghunt hunt.py <email_address>
+docker run --privileged -v $(pwd)/resources:/usr/src/app/resources -ti ghunt check_and_gen.py
+docker run --privileged -v $(pwd)/resources:/usr/src/app/resources -ti ghunt hunt.py <email_address>
 ```
 
 ## Manual installation

--- a/check_and_gen.py
+++ b/check_and_gen.py
@@ -10,9 +10,9 @@ cookies = ""
 auth = ""
 keys = ""
 already_exists = False
-if isfile('data.txt'):
+if isfile(cfg['data_path']):
     try:
-        with open('data.txt', 'r') as f:
+        with open(cfg['data_path'], 'r') as f:
             out = json.loads(f.read())
             auth = out["auth"]
             hangouts_token = out["keys"]
@@ -93,5 +93,5 @@ hangouts_token = req.url.split("key=")[1]
 print("Hangouts Token => {}".format(hangouts_token))
 
 output = {"auth": auth, "keys": {"gdoc": gdoc_token, "hangouts": hangouts_token}, "cookies": cookies}
-with open('data.txt', 'w') as f:
+with open(cfg['data_path'], 'w') as f:
 	f.write(json.dumps(output))

--- a/config.py
+++ b/config.py
@@ -8,5 +8,6 @@ cfg = dict(
 headless = False, # if True, it doesn't show the browser while scraping GMaps reviews
 ytb_hunt_always = False, # if True, search the Youtube channel everytime
 gmaps_radius = 30, # in km. The radius distance to create groups of gmaps reviews.
-gdocs_public_doc = "1jaEEHZL32t1RUN5WuZEnFpqiEPf_APYKrRBG9LhLdvE" # The public Google Doc to use it as an endpoint, to use Google's Search.
+gdocs_public_doc = "1jaEEHZL32t1RUN5WuZEnFpqiEPf_APYKrRBG9LhLdvE", # The public Google Doc to use it as an endpoint, to use Google's Search.
+data_path = "resources/data.txt"
 )

--- a/hunt.py
+++ b/hunt.py
@@ -13,19 +13,18 @@ import lib.gmaps as gmaps
 from config import cfg
 from os.path import isfile
 
-
 if len(sys.argv) <= 1:
 	exit("Please put an email address.")
 
 query = sys.argv[1]
 
-if not isfile('data.txt'):
+if not isfile(cfg['data_path']):
 	exit("Please generate cookies and tokens first.")
 
 cookies = ""
 auth = ""
 key = ""
-with open('data.txt', 'r') as f:
+with open(cfg['data_path'], 'r') as f:
 	out = json.loads(f.read())
 	auth = out["auth"]
 	hangouts_token = out["keys"]["hangouts"]

--- a/lib/search.py
+++ b/lib/search.py
@@ -5,7 +5,7 @@ from pprint import pprint
 def search(query, cfg):
 	cookies = ""
 	token = ""
-	with open('data.txt', 'r') as f:
+	with open(cfg['data_path'], 'r') as f:
 		out = json.loads(f.read())
 		token = out["keys"]["gdoc"]
 		cookies = out["cookies"]


### PR DESCRIPTION
A basic dockerization. Some notes:

- An user could be created so that the script is executed by a non-root. Decided to keep it easy for now.
- The `data.txt` should now be under the `resources/` folder so that it's easier to mount to Docker.
- Removed the hardcoded `data.txt` and moved it to the `cfg` dict.
- This will become way more useful if a GitHub action or any other CI/CD builds it and publishes it to Docker Hub so people can just pull and use it instead of having to build it.

Cheers!