### PR TITLE
Add the official dependabot implementation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
This basically adds dependabot, which keeps dependencies up-to-date. Will need to create a pr label called `dependencies` for it to work correctly.