### PR TITLE
Fix Youtube get_confidence returning None when no channels

### DIFF
--- a/lib/youtube.py
+++ b/lib/youtube.py
@@ -119,6 +119,7 @@ def get_confidence(data, query, hash):
         if len(chans) > 1:
             panel-=5
         return (panel/maxscore*100), chans
+    return 0, []
 
 def extract_usernames(channels):
     return [chan['profil_url'].split("/user/")[1] for chan in channels if "/user/" in chan['profil_url']]


### PR DESCRIPTION
When the channels array was empty in the json provided in the data parameter of get_confidence for Youtube, nothing was being returned which broke hunt.py. Empty channels with 0 confidence are now returned and things continue to work correctly.