### PR TITLE
Search chromedriver in PATH before local directory

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -51,9 +51,9 @@ def sanitize_location(location):
 
 def get_driverpath():
     tmprinter = TMPrinter()
-    drivers = [str(x.absolute()) for x in Path('.').rglob('chromedriver*')]
+    drivers = shutil.which("chromedriver")
     if not drivers:
-        drivers = shutil.which("chromedriver")
+        drivers = [str(x.absolute()) for x in Path('.').rglob('chromedriver*')]
     if drivers:
         return drivers[0]
     else:


### PR DESCRIPTION
In my local setup, I installed my virtual env directory in the local directory, leading to many invalid results when running the get_driverpath method:

> ['/Users/pgreze/git/GHunt/env/bin/chromedriver-path', '/Users/pgreze/git/GHunt/env/lib/python3.8/site-packages/chromedriver_autoinstaller', '/Users/pgreze/git/GHunt/env/lib/python3.8/site-packages/chromedriver_autoinstaller-0.2.2.dist-info']

After realizing I had to install chromedriver with homebrew, it was still not working. That's why I'd like to promote PATH discovery before local directory one.

Notice the issue will remain for people having a local env in their local directory :(
Also the README sentence:

> ⚠️ So just make sure to have Google Chrome installed.

seems wrong but because I don't know what are best practices for chromedriver installations, let me push only this change so far.