### PR TITLE
Fix crashes caused by non-robust parsing process.

### DIFF
--- a/hunt.py
+++ b/hunt.py
@@ -53,9 +53,15 @@ if __name__ == "__main__":
         # get name
         name = get_account_name(client, gaiaID)
         if name:
-            print(f"Name: {name}")
+            print(f"Name : {name}")
         else:
-            print("Couldn't find name")
+            if "name" not in infos:
+                print("Couldn't find name")
+            else:
+                for i in range(len(infos["name"])):
+                    print(f"Name : {infos['name'][i]['displayName']}")
+                if len(infos["name"]) > 0:
+                    name = infos["name"][0]["displayName"]
 
         # last edit
         timestamp = int(infos["metadata"]["lastUpdateTimeMicros"][:-3])
@@ -65,11 +71,14 @@ if __name__ == "__main__":
 
         # is bot?
         profile_pic = infos["photo"][0]["url"]
-        isBot = infos["extendedData"]["hangoutsExtendedData"]["isBot"]
-        if isBot:
-            print("Hangouts Bot : Yes !\n")
+        if "extendedData" in infos:
+            isBot = infos["extendedData"]["hangoutsExtendedData"]["isBot"]
+            if isBot:
+                print("Hangouts Bot : Yes !")
+            else:
+                print("Hangouts Bot : No")
         else:
-            print("Hangouts Bot : No")
+            print("Hangouts Bot : Unknown")
 
         # decide to check YouTube
         ytb_hunt = False

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from os.path import isfile
 
@@ -32,10 +33,11 @@ def is_email_google_account(httpx_client, auth, cookies, email, hangouts_token):
     return data
 
 def get_account_name(httpx_client, gaiaID):
-    req = httpx_client.get(f"https://www.google.com/maps/contrib/{gaiaID}")
-    gmaps_source = req.text
-    name = gmaps_source.split("Contributions by")[1].split('"')[0].strip()
-    return name
+    gmaps_source = httpx_client.get(f"https://www.google.com/maps/contrib/{gaiaID}").text
+    match = re.search(r'<meta content="Contributions by (.*?)" itemprop="name">', gmaps_source)
+    if match is None:
+        return None
+    return match[1]
 
 def image_hash(img):
     hash = str(imagehash.average_hash(img))

--- a/lib/youtube.py
+++ b/lib/youtube.py
@@ -78,7 +78,7 @@ def youtube_channel_search_gdocs(client, query, data_path, gdocs_public_doc):
         hash = image_hash(img)
         title = data["metadata"]["channelMetadataRenderer"]["title"]
         results["channels"].append({"profile_url": profile_url, "name": title, "hash": hash})
-        
+
     return results
 
 


### PR DESCRIPTION
When I test the scripts, I noticed that some accounts return some weird data and the scripts will crash due to unexpected data format.

e.g. some accounts doesn't show their name in Google Maps, their gmaps_sources looks like the following
```
<!DOCTYPE html>
<html itemscope="" itemtype="http://schema.org/Place" lang="zh-HK">

<head>
  <link href="/maps/preview/opensearch.xml?hl=zh-TW" title="Google 地圖" rel="search"
    type="application/opensearchdescription+xml">
  <title> Google 地圖 </title>
  <meta content="利用「Google 地圖」尋找本地商家、檢視地圖或規劃行車路線。" name="Description">
  <meta content="initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" name="viewport">
  <meta content="chrome=1" http-equiv="X-UA-Compatible">
  <meta content="notranslate" name="google">
  <meta content="origin" name="referrer">
  <meta content="My Contributions to Google Maps" itemprop="name">
  <meta content="My Contributions to Google Maps" property="og:title">
  <meta content="//www.gstatic.com/images/branding/product/1x/maps_round_512dp.png" itemprop="image">
  <meta content="//www.gstatic.com/images/branding/product/1x/maps_round_512dp.png" property="og:image">
  <meta content="256" property="og:image:width">
  <meta content="256" property="og:image:height">
  <meta content="My Contributions to Google Maps" property="og:site_name">
  <meta content="summary" name="twitter:card">
```

So I spent some time going through the parsing logic and made few fixes for those wired accounts.