### PR TITLE
extract gdoc_token by a webdriver instead of httpx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ data.txt
 login.py
 .DS_Store
 debug.log
+*.env
+.vscode


### PR DESCRIPTION
This is a fix for the recent changes that google has made.

**Old scenario**: `get_authorization_source()` was returning an HTML source from hangouts by sending an HTTP request using HTTPX lib to extract the gdoc_token, but after the recent changes by google – which might be extra anti-bot detection – the returned HTML source becomes no longer contain gdoc_token.

**New scenario**: `get_authorization_source()` uses a selenium web driver instead of HTTPX lib to extract gdoc_token.