### PR TITLE
Switching from hangouts to chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ data.txt
 login.py
 .DS_Store
 debug.log
+*.env
+.vscode

--- a/check_and_gen.py
+++ b/check_and_gen.py
@@ -50,11 +50,11 @@ def get_authorization_source(driver):
     return None
 
 
-def save_tokens(gdoc_token, hangouts_auth, hangouts_token, internal_token, internal_auth, cac_key, cookies, osid):
+def save_tokens(gdoc_token, chat_key, chat_auth, internal_token, internal_auth, cac_key, cookies, osid):
     '''Ssave tokens to file '''
     output = {
-        "hangouts_auth": hangouts_auth, "internal_auth": internal_auth,
-        "keys": {"gdoc": gdoc_token, "hangouts": hangouts_token, "internal": internal_token, "clientauthconfig": cac_key},
+        "chat_auth": chat_auth, "internal_auth": internal_auth,
+        "keys": {"gdoc": gdoc_token, "chat": chat_key, "internal": internal_token, "clientauthconfig": cac_key},
         "cookies": cookies,
         "osids": {
             "cloudconsole": osid
@@ -64,14 +64,14 @@ def save_tokens(gdoc_token, hangouts_auth, hangouts_token, internal_token, inter
         f.write(json.dumps(output))
 
 
-def get_hangouts_tokens(cookies):
-    """ Return the API key used by Hangouts for
+def get_chat_tokens(cookies):
+    """ Return the API key used by Google Chat for
         Internal People API and a generated SAPISID hash."""
 
-    hangouts_key = "AIzaSyD7InnYR3VKdb4j2rMUEbTCIr2VyEazl6k"
-    hangouts_auth = f"SAPISIDHASH {gen_sapisidhash(cookies['SAPISID'], 'https://hangouts.google.com')}"
+    chat_key = "AIzaSyB0RaagJhe9JF2mKDpMml645yslHfLI8iA"
+    chat_auth = f"SAPISIDHASH {gen_sapisidhash(cookies['SAPISID'], 'https://chat.google.com')}"
 
-    return (hangouts_auth, hangouts_key)
+    return (chat_key, chat_auth)
 
 def get_people_tokens(cookies):
     """ Return the API key used by Drive for
@@ -244,12 +244,13 @@ if __name__ == '__main__':
     print(f"People API Key => {people_key}")
     print(f"People API Auth => {people_auth}")
 
-    # Extracting Hangouts tokens
-    hangouts_key, hangouts_token = get_hangouts_tokens(cookies_with_osid)
-    print(f"Hangouts Key => {hangouts_token}")
-    print(f"Hangouts Auth => {hangouts_key}")
+
+    # Extracting Chat tokens
+    chat_key, chat_auth = get_chat_tokens(cookies_with_osid)
+    print(f"Chat Key => {chat_key}")
+    print(f"Chat Auth => {chat_auth}")
 
     cac_key = get_clientauthconfig_key(cookies_with_osid)
     print(f"Client Auth Config API Key => {cac_key}")
 
-    save_tokens(gdoc_token, hangouts_key, hangouts_token, people_key, people_auth, cac_key, cookies, osid)
+    save_tokens(gdoc_token, chat_key, chat_auth, people_key, people_auth, cac_key, cookies, osid)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -69,16 +69,16 @@ def update_emails(emails, data):
 
     return emails
 
-def is_email_google_account(httpx_client, auth, cookies, email, hangouts_token):
+def is_email_google_account(httpx_client, auth, cookies, email, key):
     host = "https://people-pa.clients6.google.com"
-    url = "/v2/people/lookup?key={}".format(hangouts_token)
-    body = """id={}&type=EMAIL&matchType=EXACT&extensionSet.extensionNames=HANGOUTS_ADDITIONAL_DATA&extensionSet.extensionNames=HANGOUTS_OFF_NETWORK_GAIA_LOOKUP&extensionSet.extensionNames=HANGOUTS_PHONE_DATA&coreIdParams.useRealtimeNotificationExpandedAcls=true&requestMask.includeField.paths=person.email&requestMask.includeField.paths=person.gender&requestMask.includeField.paths=person.in_app_reachability&requestMask.includeField.paths=person.metadata&requestMask.includeField.paths=person.name&requestMask.includeField.paths=person.phone&requestMask.includeField.paths=person.photo&requestMask.includeField.paths=person.read_only_profile_info&requestMask.includeContainer=AFFINITY&requestMask.includeContainer=PROFILE&requestMask.includeContainer=DOMAIN_PROFILE&requestMask.includeContainer=ACCOUNT&requestMask.includeContainer=EXTERNAL_ACCOUNT&requestMask.includeContainer=CIRCLE&requestMask.includeContainer=DOMAIN_CONTACT&requestMask.includeContainer=DEVICE_CONTACT&requestMask.includeContainer=GOOGLE_GROUP&requestMask.includeContainer=CONTACT"""
+    url = "/v2/people/lookup?key={}".format(key)
+    body = """id={}&type=EMAIL&matchType=EXACT&coreIdParams.useRealtimeNotificationExpandedAcls=true&requestMask.includeField.paths=person.email&requestMask.includeField.paths=person.gender&requestMask.includeField.paths=person.in_app_reachability&requestMask.includeField.paths=person.metadata&requestMask.includeField.paths=person.name&requestMask.includeField.paths=person.phone&requestMask.includeField.paths=person.photo&requestMask.includeField.paths=person.read_only_profile_info&requestMask.includeContainer=AFFINITY&requestMask.includeContainer=PROFILE&requestMask.includeContainer=DOMAIN_PROFILE&requestMask.includeContainer=ACCOUNT&requestMask.includeContainer=EXTERNAL_ACCOUNT&requestMask.includeContainer=CIRCLE&requestMask.includeContainer=DOMAIN_CONTACT&requestMask.includeContainer=DEVICE_CONTACT&requestMask.includeContainer=GOOGLE_GROUP&requestMask.includeContainer=CONTACT"""
 
     headers = {
         "X-HTTP-Method-Override": "GET",
         "Authorization": auth,
         "Content-Type": "application/x-www-form-urlencoded",
-        "Origin": "https://hangouts.google.com"
+        "Origin": "https://chat.google.com"
     }
 
     req = httpx_client.post(host + url, data=body.format(email), headers=headers, cookies=cookies)

--- a/modules/email.py
+++ b/modules/email.py
@@ -30,9 +30,9 @@ def email_hunt(email):
 
     if not isfile(config.data_path):
         exit("Please generate cookies and tokens first, with the check_and_gen.py script.")
-
-    hangouts_auth = ""
-    hangouts_token = ""
+    
+    chat_auth = ""
+    chat_key = ""
     internal_auth = ""
     internal_token = ""
 
@@ -40,16 +40,16 @@ def email_hunt(email):
 
     with open(config.data_path, 'r') as f:
         out = json.loads(f.read())
-        hangouts_auth = out["hangouts_auth"]
-        hangouts_token = out["keys"]["hangouts"]
+        chat_auth = out["chat_auth"]
+        chat_key = out["keys"]["chat"]
         internal_auth = out["internal_auth"]
         internal_token = out["keys"]["internal"]
         cookies = out["cookies"]
 
     client = httpx.Client(cookies=cookies, headers=config.headers)
 
-    data = is_email_google_account(client, hangouts_auth, cookies, email,
-                                   hangouts_token)
+    data = is_email_google_account(client, chat_auth, cookies, email,
+                                   chat_key)
 
     is_within_docker = within_docker()
     if is_within_docker:


### PR DESCRIPTION
In reference to this [issue](https://github.com/mxrch/GHunt/issues/382), I figured out the reason behind it.

In short: Google has migrated Hangouts to Chat, so Hangouts no longer exist, and some parts of the code still use some hangouts stuff.

**The solution**:

- Removed Hangouts key and hash token from `data.txt`
- Replaced Hangouts key with Chat key
- Dynamically generating Chat token based on the Chat key and the Chat origin: 'chat.google.com'
- Saving Chat key and token in `data.txt` file

    _in `is_email_google_account()` func:_
- Using Chat key and token instead of Hangout's ones
- Removed all Hangouts claims from the URL
- Replaced the origin 'hangouts.google.com' by 'chat.google.com'

Be noted that this pull request includes [380](https://github.com/mxrch/GHunt/pull/380)'s changes.
