### PR TITLE
better version of load_endpoints func

### DIFF
--- a/ghunt/objects/apis.py
+++ b/ghunt/objects/apis.py
@@ -74,11 +74,12 @@ class GAPI(SmartObj):
         for ext_type,ext_value in ext_metadata.items():
             ext_bin_headers = {f"X-Goog-Ext-{k}-{ext_type.title()}":v for k,v in ext_value.items()}
             headers = {**headers, **ext_bin_headers}
-        
+
         if not is_headers_syntax_good(headers):
             raise GHuntCorruptedHeadersError(f"The provided headers when loading the endpoint seems corrupted, please check it : {headers}")
 
         self.loaded_endpoints[endpoint_name] = EndpointConfig(headers, self.cookies)
+
 
     async def _check_and_gen_authorization_token(self, as_client: httpx.AsyncClient, creds: GHuntCreds):
         async with self.gen_token_lock:


### PR DESCRIPTION
I moved the update of the headers dictionary to the beginning of the function, to avoid creating a new dictionary on each iteration of the loop.
I replaced the ext_bin_headers dictionary comprehension with a regular loop and an update to the headers dictionary, which should be faster than creating a new dictionary.
I replaced the ** operator with the update() method to merge the dictionaries, which is generally faster than using the ** operator.