### PR TITLE
Handled null profile edit date.

### DIFF
--- a/ghunt/modules/email.py
+++ b/ghunt/modules/email.py
@@ -72,7 +72,8 @@ async def hunt(as_client: httpx.AsyncClient, email_address: str, json_file: bool
             await ia.detect_face(vision_api, as_client, target.coverPhotos[container].url)
             print()
 
-    print(f"Last profile edit : {target.sourceIds[container].lastUpdated.strftime('%Y/%m/%d %H:%M:%S (UTC)')}\n")
+    if target.sourceIds[container].lastUpdated is not None:
+        print(f"Last profile edit : {target.sourceIds[container].lastUpdated.strftime('%Y/%m/%d %H:%M:%S (UTC)')}\n")
     
     if container in target.emails:
         print(f"Email : {target.emails[container].value}")


### PR DESCRIPTION
Was getting this error when trying to search an email without any "last edited date" on the profile: 

```
print(f"Last profile edit : {target.sourceIds[container].lastUpdated.strftime('%Y/%m/%d %H:%M:%S (UTC)')}\n")
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'strftime'
```

Handled by adding an if condition to verify that `lastUpdated` isn't None. Resolved my issue.
