### PR TITLE
[fix for Invalid Cookies] Make GHunt accept all cookies

### DIFF
--- a/ghunt/helpers/auth.py
+++ b/ghunt/helpers/auth.py
@@ -96,10 +96,6 @@ def check_cookies(cookies: Dict[str, str]) -> bool:
     if req.status_code != 307:
         return False
 
-    set_cookies = extract_set_cookies(req)
-    if any([cookie in set_cookies for cookie in cookies]):
-        return False
-
     return True
 
 def check_osids(cookies: Dict[str, str], osids: Dict[str, str]) -> bool:

--- a/ghunt/helpers/auth.py
+++ b/ghunt/helpers/auth.py
@@ -131,7 +131,7 @@ async def getting_cookies_dialog(cookies: Dict[str, str]) -> Tuple[Dict[str, str
                 "=> https://github.com/mxrch/ghunt_companion\n\n"
                 "[1] (Companion) Put GHunt on listening mode (currently not compatible with docker)\n"
                 "[2] (Companion) Paste base64-encoded cookies\n"
-                "[3] Enter manually all cookies\n\n"
+                "[3] Enter manually all cookies (currently not supported)\n\n"
                 "Choice => ")
 
     choice = input(choices)
@@ -145,9 +145,10 @@ async def getting_cookies_dialog(cookies: Dict[str, str]) -> Tuple[Dict[str, str
         oauth_token = data["oauth_token"]
 
     elif choice == "3":
-        for name in cookies.keys():
-            cookies[name] = input(f"{name} => ").strip().strip('"')
-        oauth_token = input(f"oauth_token").strip().strip('"')
+        exit("This option is temporary not supported, please use other options. Exiting...")
+        # for name in cookies.keys():
+        #     cookies[name] = input(f"{name} => ").strip().strip('"')
+        # oauth_token = input(f"oauth_token").strip().strip('"')
 
     else:
         exit("Please choose a valid choice. Exiting...")


### PR DESCRIPTION
This is a solution for these issues.
- #476 
- #479 
- #456 

Due to changes in Google Authentication, GHunt does not work as for 2024/01/11.
I've figured out that including all cookies will work.

I submitted a PR in [mxrch/ghunt_companion](https://github.com/mxrch/ghunt_companion/pull/4), which will pass all cookies to GHunt on authentication.
There was some codes that prevents doing so in GHunt, so I removed that.
https://github.com/mxrch/GHunt/blob/e87346963658dd8d80cef49dbf1bd263e96d352e/ghunt/helpers/auth.py#L99C1-L101C21

Required cookies are remained unidentified, so I marked `Enter manually all cookies` as currently not supported.