### PR TITLE
Use distinct exit codes for intentional exits

### DIFF
--- a/examples/email_registered.py
+++ b/examples/email_registered.py
@@ -1,3 +1,5 @@
+import os
+
 import httpx
 import asyncio
 
@@ -8,7 +10,8 @@ from ghunt.helpers.gmail import is_email_registered
 
 async def main():
     if not sys.argv[1:]:
-        exit("Please give an email address.")
+        print("Please give an email address.")
+        exit(os.EX_IOERR)
 
     as_client = httpx.AsyncClient() # Async Client
 

--- a/ghunt/ghunt.py
+++ b/ghunt/ghunt.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 
@@ -6,7 +7,7 @@ def main():
     if (version < (3, 10)):
         print('[-] GHunt only works with Python 3.10+.')
         print(f'Your current Python version : {version.major}.{version.minor}.{version.micro}')
-        sys.exit(1)
+        sys.exit(os.EX_SOFTWARE)
 
     from ghunt.cli import parse_and_run
     from ghunt.helpers.banner import show_banner

--- a/ghunt/helpers/auth.py
+++ b/ghunt/helpers/auth.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import base64
+import os
 from typing import *
 
 import httpx
@@ -195,7 +196,8 @@ def auth_dialog() -> Tuple[Dict[str, str], str] :
         master_token = input(f"Master token => ").strip('" ')
 
     else:
-        exit("Please choose a valid choice. Exiting...")
+        print("Please choose a valid choice. Exiting...")
+        exit(os.EX_IOERR)
 
     return oauth_token, master_token
 

--- a/ghunt/helpers/ia.py
+++ b/ghunt/helpers/ia.py
@@ -1,3 +1,5 @@
+import os
+
 from ghunt import globals as gb
 from ghunt.apis.vision import VisionHttp
 
@@ -20,7 +22,8 @@ async def detect_face(vision_api: VisionHttp, as_client: httpx.AsyncClient, imag
             break
         await asyncio.sleep(0.5)
     else:
-        exit("\n[-] Vision API keeps rate-limiting.")
+        print("\n[-] Vision API keeps rate-limiting.")
+        exit(os.EX_UNAVAILABLE)
 
     if are_faces_found:
         if len(faces_results.face_annotations) > 1:

--- a/ghunt/helpers/listener.py
+++ b/ghunt/helpers/listener.py
@@ -1,3 +1,4 @@
+import os
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import *
 
@@ -45,7 +46,8 @@ def run(server_class=HTTPServer, handler_class=Server, port=60067):
                 break
 
     except KeyboardInterrupt:
-        exit("[-] Exiting...")
+        print("[-] Exiting...")
+        exit(os.CLD_KILLED)
     else:
         if handler_class.data_bridge.data:
             print("[+] Received cookies !")

--- a/ghunt/modules/drive.py
+++ b/ghunt/modules/drive.py
@@ -1,3 +1,5 @@
+import os
+
 from ghunt.helpers.utils import *
 from ghunt.objects.base import DriveExtractedUser, GHuntCreds
 from ghunt.apis.drive import DriveHttp
@@ -38,7 +40,8 @@ async def hunt(as_client: httpx.AsyncClient, file_id: str, json_file: bool=Path)
     drive = DriveHttp(ghunt_creds)
     file_found, file = await drive.get_file(as_client, file_id)
     if not file_found:
-        exit("[-] The file wasn't found.")
+        print("[-] The file wasn't found.")
+        exit(os.EX_IOERR)
 
     is_folder = file.mime_type == "application/vnd.google-apps.folder"
     file_type = drive_knownledge.mime_types.get(file.mime_type)

--- a/ghunt/modules/email.py
+++ b/ghunt/modules/email.py
@@ -1,3 +1,5 @@
+import os
+
 from ghunt import globals as gb
 from ghunt.helpers.utils import get_httpx_client
 from ghunt.objects.base import GHuntCreds
@@ -24,7 +26,8 @@ async def hunt(as_client: httpx.AsyncClient, email_address: str, json_file: Path
     # vision_api = VisionHttp(ghunt_creds)
     is_found, target = await people_pa.people_lookup(as_client, email_address, params_template="max_details")
     if not is_found:
-        exit("[-] The target wasn't found.")
+        print("[-] The target wasn't found.")
+        exit(os.EX_DATAERR)
 
     if json_file:
         json_results = {}
@@ -37,7 +40,8 @@ async def hunt(as_client: httpx.AsyncClient, email_address: str, json_file: Path
             print(f"- {container.title()}")
 
     if not "PROFILE" in containers:
-        exit("[-] Given information does not match a public Google Account.")
+        print("[-] Given information does not match a public Google Account.")
+        exit(os.EX_DATAERR)
 
     container = "PROFILE"
     

--- a/ghunt/modules/gaia.py
+++ b/ghunt/modules/gaia.py
@@ -1,3 +1,5 @@
+import os
+
 from ghunt import globals as gb
 from ghunt.objects.base import GHuntCreds
 from ghunt.apis.peoplepa import PeoplePaHttp
@@ -24,7 +26,8 @@ async def hunt(as_client: httpx.AsyncClient, gaia_id: str, json_file: Path=None)
     # vision_api = VisionHttp(ghunt_creds)
     is_found, target = await people_pa.people(as_client, gaia_id, params_template="max_details")
     if not is_found:
-        exit("[-] The target wasn't found.")
+        print("[-] The target wasn't found.")
+        exit(os.EX_DATAERR)
 
     if json_file:
         json_results = {}
@@ -37,7 +40,8 @@ async def hunt(as_client: httpx.AsyncClient, gaia_id: str, json_file: Path=None)
             print(f"- {container.title()}")
 
     if not "PROFILE" in containers:
-        exit("[-] Given information does not match a public Google Account.")
+        print("[-] Given information does not match a public Google Account.")
+        exit(os.EX_DATAERR)
 
     container = "PROFILE"
     

--- a/ghunt/modules/login.py
+++ b/ghunt/modules/login.py
@@ -1,3 +1,4 @@
+import os
 from typing import *
 
 import httpx
@@ -22,7 +23,7 @@ async def check_and_login(as_client: httpx.AsyncClient, clean: bool=False) -> No
             print(f"[+] Credentials file at {creds_path} deleted !")
         else:
             print(f"Credentials file at {creds_path} doesn't exists, no need to delete.")
-        exit()
+        exit(os.EX_OK)
 
     if not as_client:
         as_client = get_httpx_client()
@@ -59,7 +60,7 @@ async def check_and_login(as_client: httpx.AsyncClient, clean: bool=False) -> No
         if new_gen_inp == "y":
             oauth_token, master_token = auth.auth_dialog()
         else:
-            exit()
+            exit(os.EX_OK)
 
     ghunt_creds.android.authorization_tokens = {} # Reset the authorization tokens
 


### PR DESCRIPTION
Currently, all the intentional application exits look like this:
```python
exit("Please give an email address.")
```
This causes all exit codes to be `1`. That's the same exit code when an Error is raised. This means, it is impossible to distinguish programmatically, if the application crashed, or halted gracefully. That can be important, when this application is called e. g. from within a script.

This pull request fixes this issue, by splitting all `exit(<string>)` occurrences in a `print(<string>)` call, followed by a `exit()` with a suitable code from the `os` package. For example:

```python
print("Please give an email address.")
exit(os.EX_IOERR)
```

I would highly appreciate, if this pull request would be merged. I can't imagine a scenario, where this change has any negative effect.