### PR TITLE
fix: handle missing container key in cover photo metadata and undefined photos/reviews variables

### DIFF
--- a/ghunt/modules/email.py
+++ b/ghunt/modules/email.py
@@ -146,8 +146,8 @@ async def hunt(as_client: httpx.AsyncClient, email_address: str, json_file: Path
                 "profile": target,
                 "play_games": player if player_results else None,
                 "maps": {
-                    "photos": photos,
-                    "reviews": reviews,
+                    "photos": None,
+                    "reviews": None,
                     "stats": stats
                 },
                 "calendar": {

--- a/ghunt/parsers/people.py
+++ b/ghunt/parsers/people.py
@@ -161,7 +161,8 @@ class Person(Parser):
             for cover_photo_data in person_data["coverPhoto"]:
                 person_cover_photo = PersonPhoto()
                 await person_cover_photo._scrape(as_client, cover_photo_data, "cover_photo")
-                self.coverPhotos[cover_photo_data["metadata"]["container"]] = person_cover_photo
+                container = cover_photo_data.get("metadata", {}).get("container", "unknown")
+                self.coverPhotos[container] = person_cover_photo
 
         if (apps_data := person_data.get("inAppReachability")):
             containers_names = set()


### PR DESCRIPTION
## Problem
Two bugs causing GHunt to crash:

1. `KeyError: 'container'` in `parsers/people.py` when a Google account's cover photo metadata is missing the `container` field.

2. `NameError: name 'photos' is not defined` in `modules/email.py` because `photos` and `reviews` are referenced in the JSON output block but `get_reviews()` only returns `err` and `stats`.

## Fix
- `parsers/people.py`: Use `.get()` with `"unknown"` fallback instead of direct key access
- `modules/email.py`: Set `photos` and `reviews` to `None` since they are not returned by `get_reviews()` yet
