### PR TITLE
fix: replace bare except with except Exception in gmaps/utils helpers

### DIFF
--- a/ghunt/helpers/gmaps.py
+++ b/ghunt/helpers/gmaps.py
@@ -289,7 +289,7 @@ def calculate_probable_location(geolocator: Nominatim, reviews_and_photos: List[
                 try:
                     location = geolocator.reverse(f"{avg[0]}, {avg[1]}", timeout=10).raw["address"]
                     break
-                except:
+                except Exception:
                     pass
             location = sanitize_location(location)
             locs[nb]["avg"] = location

--- a/ghunt/helpers/utils.py
+++ b/ghunt/helpers/utils.py
@@ -54,7 +54,7 @@ def is_headers_syntax_good(headers: Dict[str, str]) -> bool:
     try:
         httpx.Headers(headers)
         return True
-    except:
+    except Exception:
         return False
 
 async def get_url_image_flathash(as_client: httpx.AsyncClient, image_url: str) -> str:


### PR DESCRIPTION

### Summary

Two bare `except:` clauses swallow everything, including
`KeyboardInterrupt`/`SystemExit`:

- `ghunt/helpers/gmaps.py` (geolocation reverse lookup retry loop) — intended
  to skip a failed reverse-geocode lookup
- `ghunt/helpers/utils.py` (`is_headers_syntax_good`) — intended to return
  False on invalid headers

Replace both with `except Exception:` — same intended behavior, but
unexpected exceptions (e.g. `NameError`) now propagate instead of being
hidden.

### Verification

- `python -m py_compile ghunt/helpers/gmaps.py ghunt/helpers/utils.py` → OK
- `grep -rn "except:" ghunt/` → 0 remaining bare handlers

### Files changed

- `ghunt/helpers/gmaps.py` (1 line)
- `ghunt/helpers/utils.py` (1 line)